### PR TITLE
:lock: Fix collision bug

### DIFF
--- a/blockhash/mains.py
+++ b/blockhash/mains.py
@@ -23,6 +23,7 @@ def chunks(file_object, chunk_size=20971520):
         yield data
 
 def hashing(piece):
+    piece += ":chunk"
     if args.sha1:
         return str(hashlib.sha1(piece).hexdigest())
     elif args.sha224:
@@ -45,12 +46,12 @@ def main():
     parser.add_argument('-4', '--sha384', action='store_true')
     parser.add_argument('-5', '--sha512', action='store_true')
     parser.add_argument('-f', '--file', type=str, help="The path to the file")
-    
+
     if len(sys.argv) == 1:
         parser.print_help()
         return
 
-    global args 
+    global args
     args = parser.parse_args()
 
     hashtree = ''
@@ -59,14 +60,11 @@ def main():
     pool = Pool(multiprocessing.cpu_count())
 
     for chunk_hash in pool.imap(hashing, chunks(big_file)):
-        hashtree = hashtree + chunk_hash
+        hashtree += chunk_hash + ":hash"
 
-    pool.terminate() 
+    pool.terminate()
 
-    if os.path.getsize(args.file) < 20971520:
-        print(hashtree)
-    else:
-        print(str(hashing(hashtree)))
+    print(str(hashing(hashtree)))
 
 
 if __name__ == '__main__':

--- a/blockhash/mains.py
+++ b/blockhash/mains.py
@@ -20,10 +20,9 @@ def chunks(file_object, chunk_size=20971520):
         data = file_object.read(chunk_size)
         if not data:
             break
-        yield data
+        yield data + ":chunk"
 
 def hashing(piece):
-    piece += ":chunk"
     if args.sha1:
         return str(hashlib.sha1(piece).hexdigest())
     elif args.sha224:
@@ -64,7 +63,7 @@ def main():
 
     pool.terminate()
 
-    print(str(hashing(hashtree)))
+    print(str(hashing(hashtree.encode('ascii'))))
 
 
 if __name__ == '__main__':

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,26 +3,25 @@ from nose.tools import eq_, ok_
 
 def test_sha1():
 	function_output = subprocess.check_output("python ./blockhash/mains.py -1 --file ./images/test.png", shell=True).rstrip().decode("utf-8")
-	desired_output = "e45eabab13f84de0bb24fb5f5ddd57d462ebbf57"
+	desired_output = "b87076dd43116c293f3140d6cce605db04a88d6f"
 	eq_(desired_output ,function_output)
 
 def test_sha224():
 	function_output = subprocess.check_output("python ./blockhash/mains.py -2 --file ./images/test.png", shell=True).rstrip().decode("utf-8")
-	desired_output = "1a52bf0a20c734839167bb7b5b2ccd271e0ce9d523585439ac950917"
+	desired_output = "68ca0ab03dade888dd3965a38d62d6014a696ee3d3a2dc19148510b7"
 	eq_(desired_output,function_output)
 
 def test_sha256():
-	function_output = subprocess.check_output("python ./blockhash/mains.py -3 --file ./images/test.png", shell=True).rstrip().decode("utf-8") 
-	desired_output = "16b6eb59000c18eb3a361aab1c228e18f441cf79da5b665f70230d60b671809e"
+	function_output = subprocess.check_output("python ./blockhash/mains.py -3 --file ./images/test.png", shell=True).rstrip().decode("utf-8")
+	desired_output = "f879be85fb0df9e44390b7d9f13af07765a5814576c90dd4a1e756c48b89f83d"
 	eq_(desired_output,function_output)
 
 def test_sha384():
 	function_output = subprocess.check_output("python ./blockhash/mains.py -4 --file ./images/test.png", shell=True).rstrip().decode("utf-8")
-	desired_output = "e1f6d95b7c5136ac52335ea1a645936e46ffdf75b52e31d8f3899866b92205356ec9c4f7238145b2bc5d6178a0c78fc0"
+	desired_output = "305220a536c12b3ce80156047f900ef483b67d83e82cff183623316537567ea54284c676db6ff433560696cde3020a83"
 	eq_(desired_output,function_output)
 
 def test_sha512():
-	function_output = subprocess.check_output("python ./blockhash/mains.py -5 --file ./images/test.png", shell=True).rstrip().decode("utf-8") 
-	desired_output = "bc12b37fa6a252a65eb25203de4526148c6801098d188fa0e7b39cae32f0d6881ecfe7f9040a3722e93f286f2ddb1d5f3188dd45936ad1a2c3b7176c818053b9"
+	function_output = subprocess.check_output("python ./blockhash/mains.py -5 --file ./images/test.png", shell=True).rstrip().decode("utf-8")
+	desired_output = "7d130cf7198e22a69ce182db5886c19f989ff6ffc42a7bd98f444a3e044651a0aa3de97d79b26bb9184940d4e4039ebe8eeee057b9cf2d6bfa76e0a8dc6bfbb1"
 	eq_(desired_output,function_output)
-


### PR DESCRIPTION
Unfortunately, you broke SHA. :(

The whole point of SHA is to be collision resistant, which is part of the reason why we use it for file hashes. The way you've designed your algorithm, it's easy to construct collisions between files.

Consider one file, which contains exactly 20MB of the letter "a". Consider another file, which just contains the sha256 hash for the 20MB of "a"s. With your algorithm, the small file will just be hashed once and returned. The larger file will be hashed twice, and thus will return the same result as in "a".

Luckily, there's an easy fix - just post- (or pre-) pend some characters to every chunk, and then a different string to every hash.
